### PR TITLE
fix: domain and service name

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -26,5 +26,5 @@ custom:
     domainName: ${env:CUSTOM_DOMAIN}
     stage: ${self:provider.stage}
     basePath: ${self:provider.stage}
-    certificateName: '${env:CUSTOM_DOMAIN}'
+    certificateName: ${env:CERTIFICATE_NAME}
     createRoute53Record: true

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -1,4 +1,4 @@
-service: aws-python-project
+service: serverless-naruhodoo
 
 frameworkVersion: '3'
 


### PR DESCRIPTION
이 PR은 두 가지 이름 변경을 포함합니다.

1. URL 구조 개선을 위해 도메인 네임과 인증 네임을 구분하도록 환경 변수의 이름을 변경합니다.
2. serverless helloworld 예제에서 사용했던 서비스 이름을 적절하게 변경합니다.

따라서 이 PR 이후, 개발자는 자신의 로컬 환경에 `CERTIFICATE_NAME` 환경 변수를 추가로 설정해야 합니다.
이제 설정해야 하는 환경 변수는 총 3개 입니다.
- `AWS_PROFILE`: aws credential profile (~/.aws/credentials 확인)
- `CUSTOM_DOMAIN`: `api.<domain_name>`
- `CERTIFICATE_NAME`: `<domain_name>`