### PR TITLE
feat: Docker compose for local development

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -367,3 +367,6 @@ poetry.toml
 .envrc
 
 # End of https://www.toptal.com/developers/gitignore/api/python,macos,node,direnv
+
+# local test data volume
+volumes/

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3'
+
+services:
+  redis:
+    image: redis:6.2.11
+    container_name: redis
+    restart: always
+    ports:
+      - 6379:6379
+    volumes:
+      - ./volumes/redis-data:/data
+    networks:
+        - backend
+
+  db:
+    image: postgres:15.2
+    container_name: db
+    restart: always
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    ports:
+      - 5432:5432
+    volumes:
+      - ./volumes/postgres-data:/var/lib/postgresql/data
+    networks:
+        - backend
+
+networks:
+    backend:


### PR DESCRIPTION
resolves #19 

이 PR은 docker compose를 활용하여 로컬에서 다중 컨테이너 개발 환경을 쉽게 생성할 수 있도록 합니다.

대상 컨테이너
- redis 6.2.11
- postgresql 15.2

검증 방법
1. (필수) 새로운 환경변수 `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB` 임의로 설정 (로컬 개발 용도)
2. backend 폴더에서 `docker compose up -d` 실행
3. 서비스 접속 확인
  - redis → redisinsight와 같은 client로 접속 확인할 것
  - postgresql → dbeaver와 같은 client로 접속 확인할 것
