### PR TITLE
fix: Make lambda to deployed into the private subnet

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -14,8 +14,6 @@ provider:
       - ${ssm:/naruhodoo/aws/security_group}
     subnetIds:
       - ${ssm:/naruhodoo/aws/subnet1}
-      - ${ssm:/naruhodoo/aws/subnet2}
-      - ${ssm:/naruhodoo/aws/subnet3}
       - ${ssm:/naruhodoo/aws/subnet4}
   environment:
     POSTGRES_HOST: ${ssm:/naruhodoo/${self:provider.stage}/postgres/host, env:POSTGRES_HOST}


### PR DESCRIPTION
이 PR은 람다가 VPC 내 private subnet으로만 배포되도록 변경합니다.
이러한 조치를 취하는 이유는 VPC 내부에 배포되는 lambda가 NAT 없이는 internet access를 가질 수 없기 때문입니다.

관련 자료
https://stackoverflow.com/questions/75625713/how-can-i-call-websocket-apigateway-from-a-lambda-with-vpc-configuration
https://stackoverflow.com/questions/58175596/access-api-gateway-api-operation-from-vpc
https://repost.aws/ko/knowledge-center/internet-access-lambda-function