### PR TITLE
feat: CORS

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -37,24 +37,39 @@ functions:
       - http:
           path: /hello
           method: get
+          cors:
+            origin: '*'
+            headers: '*'
+
   platform:
     handler: src/lambda/handler.get_platform
     events:
       - http:
           path: /platform
           method: get
+          cors:
+            origin: '*'
+            headers: '*'
+          
   hello-redis:
     handler: src/lambda/handler.hello_redis
     events:
       - http:
           path: /hello-redis
           method: get
+          cors:
+            origin: '*'
+            headers: '*'
+
   hello-db:
     handler: src/lambda/handler.hello_db
     events:
       - http:
           path: /hello-db
           method: get
+          cors:
+            origin: '*'
+            headers: '*'
 
 custom:
   customDomain:

--- a/backend/src/lambda/handler.py
+++ b/backend/src/lambda/handler.py
@@ -2,8 +2,10 @@ import json
 import platform
 
 from src.game import app
+from src.utility.decorator import cors
 
 
+@cors
 def hello(event, context):
     msg = app.hello()
     response = {
@@ -13,6 +15,7 @@ def hello(event, context):
     return response
 
 
+@cors
 def get_platform(event, context):
     msg = platform.platform()
     response = {
@@ -22,6 +25,7 @@ def get_platform(event, context):
     return response
 
 
+@cors
 def hello_redis(event, context):
     client_info = app.hello_redis()
     response = {
@@ -31,6 +35,7 @@ def hello_redis(event, context):
     return response
 
 
+@cors
 def hello_db(event, context):
     msg = app.hello_db()
     response = {

--- a/backend/src/utility/decorator.py
+++ b/backend/src/utility/decorator.py
@@ -1,0 +1,13 @@
+import functools
+
+
+def cors(func):
+    @functools.wraps(func)
+    def wrapper(event, context):
+        response = func(event, context)
+        if 'headers' not in response:
+            response['headers'] = {}
+        response['headers']['Access-Control-Allow-Origin'] = '*'
+        response['headers']['Access-Control-Allow-Credentials'] = True
+        return response
+    return wrapper


### PR DESCRIPTION
이 PR은 CORS 관련 기능 및 예제를 포함합니다.

### 새 기능
`backend/src/utility/decorator.py`에 cors 데코레이터를 추가했습니다.
기본적으로 모든 오리진과 크레덴셜을 허용합니다.
(추후 보안을 위해 더 좁은 범위로 좁힐 수 있습니다)

### 앞으로 해야 할 것
- 이제 lambda.handler 하위에 최종적으로 배포하는 함수에 `@cors` 데코레이터를 붙여야 합니다.
(구현 예제는 PR에 포함된 `backend/src/lambda/handler.py` 참조)
- 데코레이터와는 별개로, `serverless.yml`에 배포하려는 함수의 cors 설정을 추가로 작성해야 합니다.