### PR TITLE
chore: pip

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -370,3 +370,4 @@ poetry.toml
 
 # local test data volume
 volumes/
+.pip_cache/

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -65,6 +65,8 @@ custom:
     createRoute53Record: true
   pythonRequirements:
     dockerizePip: true  # Use docker to install dependencies for non-linux environments
+    slim: true  # Slim down the size of the package by removing unneeded files
+    cacheLocation: '/Users/hoon/Projects/capstone/backend/.pip_cache'
 
 plugins:
   - serverless-python-requirements


### PR DESCRIPTION
이 PR은 pip 관련 기타 변경사항을 포함합니다.

- pip cache 경로를 backend/.pip_cache로 변경합니다.
즉, 현재 프로젝트의 pip cache와 다른 모든 프로젝트의 pip cache를 분리합니다.
이와 같이 변경하는 이유는 서로 다른 아키텍처에 대해 다른 캐시 참조가 발생할 수 있기 때문입니다. 예를 들어서, 개발 환경이 macOS-arm64인 머신에서 다른 프로젝트를 위해 `requests`라는 패키지를 받은 적이 있다고 가정해봅시다. 이때 requests 패키지는 arm64용으로 캐싱됩니다. 그런데 현재 프로젝트에서는 x86_64용 `requests`가 필요하다고 합시다. 이때 캐시가 존재하므로 이를 그대로 사용하지만, lambda 배포 시 아키텍처가 달라지므로 정상 동작하지 않습니다. 이러한 문제를 완화하기 위함입니다.

- Lambda에 배포 가능한 패키지의 크기에 제한이 있으므로, 패키지 용량을 최소화하기 위한 옵션을 적용했습니다.