### PR TITLE
feat: Sending user's opinion to same team

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -370,3 +370,4 @@ poetry.toml
 
 # local test data volume
 volumes/
+.pip_cache/

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -26,6 +26,18 @@ services:
       - ./volumes/postgres-data:/var/lib/postgresql/data
     networks:
         - backend
+  
+  dynamodb:
+    image: amazon/dynamodb-local:latest
+    container_name: dynamodb
+    restart: always
+    ports:
+      - 8000:8000
+    volumes:
+      - ./volumes/dynamodb-data:/data
+    command: "-jar DynamoDBLocal.jar -sharedDb -dbPath /data"
+    networks:
+        - backend
 
 networks:
     backend:

--- a/backend/model.sql
+++ b/backend/model.sql
@@ -1,70 +1,66 @@
-CREATE TYPE "status_enum" AS ENUM (
-  'Not yet',
-  'Running',
-  'Finished'
-);
-
-CREATE TABLE "Opinion" (
-  "opinion_id" uuid PRIMARY KEY NOT NULL,
-  "player_id" uuid NOT NULL,
-  "team_id" uuid NOT NULL,
-  "voted_count" integer NOT NULL,
-  "round" integer NOT NULL,
-  "content" text NOT NULL,
-  "timestamp" timestamp NOT NULL
-);
-
-CREATE TABLE "Player" (
-  "player_id" uuid PRIMARY KEY NOT NULL,
-  "team_id" uuid NOT NULL,
-  "connect_id" varchar(50) NOT NULL
-);
-
-CREATE TABLE "Room" (
-  "room_id" uuid PRIMARY KEY NOT NULL,
-  "current_round" integer NOT NULL,
-  "status" status_enum NOT NULL
-);
-
-CREATE TABLE "RoomConfig" (
-  "config_id" varchar(50) PRIMARY KEY NOT NULL,
-  "owner_id" uuid NOT NULL,
-  "room_id" uuid NOT NULL,
-  "title" text NOT NULL,
-  "visibility" boolean NOT NULL,
-  "switch_chance" boolean NOT NULL,
-  "max_player_count" integer NOT NULL,
-  "end_round" integer NOT NULL,
-  "round_end_time" time NOT NULL,
-  "votes_per_user" integer NOT NULL,
-  "opinion_per_user" integer NOT NULL
-);
-
-CREATE TABLE "Team" (
-  "team_id" uuid PRIMARY KEY NOT NULL,
-  "room_id" uuid NOT NULL,
-  "image" bytea NOT NULL,
-  "name" varchar(50) NOT NULL
-);
-
+CREATE TYPE "status_enum" AS ENUM ('BEFORE_OPEN', 'RUNNING', 'CLOSED');
 CREATE TABLE "User" (
-  "user_id" uuid PRIMARY KEY NOT NULL,
-  "email" varchar(320) NOT NULL,
-  "nickname" varchar(50) NOT NULL,
-  "profile" varchar(50) NOT NULL,
-  "password" varchar(50) NOT NULL
+  userId uuid NOT NULL,
+  passwd bytea NOT NULL,
+  email varchar(50) NOT NULL,
+  nickname varchar(50) NOT NULL,
+  profile varchar(50) NULL,
+  CONSTRAINT PK_USER_ID PRIMARY KEY (userId)
 );
-
-ALTER TABLE "Opinion" ADD CONSTRAINT "FK_1" FOREIGN KEY ("player_id") REFERENCES "Player" ("player_id");
-
-ALTER TABLE "Opinion" ADD CONSTRAINT "FK_7" FOREIGN KEY ("team_id") REFERENCES "Team" ("team_id");
-
-ALTER TABLE "Player" ADD CONSTRAINT "FK_2" FOREIGN KEY ("player_id") REFERENCES "User" ("user_id");
-
-ALTER TABLE "Player" ADD CONSTRAINT "FK_3" FOREIGN KEY ("team_id") REFERENCES "Team" ("team_id");
-
-ALTER TABLE "RoomConfig" ADD CONSTRAINT "FK_4" FOREIGN KEY ("owner_id") REFERENCES "User" ("user_id");
-
-ALTER TABLE "RoomConfig" ADD CONSTRAINT "FK_5" FOREIGN KEY ("room_id") REFERENCES "Room" ("room_id");
-
-ALTER TABLE "Team" ADD CONSTRAINT "FK_6" FOREIGN KEY ("room_id") REFERENCES "Room" ("room_id");
+CREATE TABLE DiscussionBattle (
+  battleId uuid NOT NULL,
+  ownerId uuid NOT NULL,
+  title varchar(50) NOT NULL,
+  status status_enum NOT NULL,
+  visibility boolean NOT NULL,
+  switchChance boolean NOT NULL,
+  startTime timestamp NULL,
+  endTime timestamp NULL,
+  description varchar(50) NULL,
+  maxNoOfPlayers integer NOT NULL,
+  maxNoIfRounds integer NOT NULL,
+  maxNoVotes integer NOT NULL,
+  maxNoOfOpinion integer NOT NULL,
+  CONSTRAINT PK_DISCUSSION_BATTLE_ID PRIMARY KEY (battleId),
+  CONSTRAINT FK_8 FOREIGN KEY (ownerId) REFERENCES "User" (userId)
+);
+CREATE TABLE Round (
+  battleId uuid NOT NULL,
+  roundNo smallserial NOT NULL,
+  startTime timestamp NOT NULL,
+  endTime timestamp NULL,
+  description varchar(50) NULL,
+  CONSTRAINT PK_ROUND_ID PRIMARY KEY (battleId, roundNo),
+  CONSTRAINT FK_1 FOREIGN KEY (battleId) REFERENCES DiscussionBattle (battleId)
+);
+CREATE TABLE Opinion (
+  userId uuid NOT NULL,
+  battleId uuid NOT NULL,
+  roundNo smallserial NOT NULL,
+  "time" timestamp NOT NULL,
+  noOfLikes integer NOT NULL,
+  content varchar(50) NOT NULL,
+  status varchar(50) NOT NULL,
+  CONSTRAINT PK_OPINION_ID PRIMARY KEY (userId, battleId, roundNo, "time"),
+  CONSTRAINT FK_2 FOREIGN KEY (battleId, roundNo) REFERENCES Round (battleId, roundNo),
+  CONSTRAINT FK_3 FOREIGN KEY (userId) REFERENCES "User" (userId)
+);
+CREATE TABLE Team (
+  teamId uuid NOT NULL,
+  battleId uuid NOT NULL,
+  name varchar(50) NOT NULL,
+  image bytea NOT NULL,
+  CONSTRAINT PK_TEAM_ID PRIMARY KEY (teamId),
+  CONSTRAINT FK_4 FOREIGN KEY (battleId) REFERENCES DiscussionBattle (battleId)
+);
+CREATE TABLE Support (
+  userId uuid NOT NULL,
+  battleId uuid NOT NULL,
+  roundNo smallserial NOT NULL,
+  vote uuid NOT NULL,
+  "time" timestamp NOT NULL,
+  CONSTRAINT PK_SUPPORT_ID PRIMARY KEY (userId, battleId, roundNo),
+  CONSTRAINT FK_5 FOREIGN KEY (userId) REFERENCES "User" (userId),
+  CONSTRAINT FK_6 FOREIGN KEY (vote) REFERENCES Team (teamId),
+  CONSTRAINT FK_7 FOREIGN KEY (battleId, roundNo) REFERENCES Round (battleId, roundNo)
+);

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ psycopg2-binary==2.9.5
 pytest==7.2.2
 redis==4.5.1
 tomli==2.0.1
+boto3

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -24,6 +24,7 @@ provider:
     REDIS_HOST: ${ssm:/naruhodoo/${self:provider.stage}/redis/host, env:REDIS_HOST}
     REDIS_PORT: ${ssm:/naruhodoo/${self:provider.stage}/redis/port, env:REDIS_PORT}
     REDIS_DB: ${ssm:/naruhodoo/${self:provider.stage}/redis/db, env:REDIS_DB}
+    DYNAMODB_WS_CONNECTION_TABLE: ${ssm:/naruhodoo/${self:provider.stage}/dynamodb/ws_connection_table, env:DYNAMODB_WS_CONNECTION_TABLE}
   iam:
     role:
       statements:
@@ -33,8 +34,9 @@ provider:
             - 'dynamodb:DeleteItem'
             - 'dynamodb:Scan'
             - 'dynamodb:GetItem'
-          Resource:
-            - 'arn:aws:dynamodb:ap-northeast-2:401482569934:table/websocket-connections-jwlee-test'
+          Resource:   #TODO: 사용하고 있는 테이블만 허용하도록 제한해야 함
+            - 'arn:aws:dynamodb:ap-northeast-2:401482569934:table/*'
+        
         - Effect: 'Allow'
           Action:
             - 'execute-api:ManageConnections'
@@ -53,24 +55,40 @@ functions:
       - http:
           path: /hello
           method: get
+          cors:
+            origin: '*'
+            headers: '*'
+
   platform:
     handler: src/lambda/handler.get_platform
     events:
       - http:
           path: /platform
           method: get
+          cors:
+            origin: '*'
+            headers: '*'
+          
   hello-redis:
     handler: src/lambda/handler.hello_redis
     events:
       - http:
           path: /hello-redis
           method: get
+          cors:
+            origin: '*'
+            headers: '*'
+
   hello-db:
     handler: src/lambda/handler.hello_db
     events:
       - http:
           path: /hello-db
           method: get
+          cors:
+            origin: '*'
+            headers: '*'
+
   connect-handler:
     handler: src/lambda/handler.connect_handler
     events:
@@ -101,6 +119,12 @@ custom:
     createRoute53Record: true
   pythonRequirements:
     dockerizePip: true  # Use docker to install dependencies for non-linux environments
+    slim: true  # Slim down the size of the package by removing unneeded files
+    cacheLocation: '.pip_cache'
+    noDeploy:
+      - pytest
+      - boto3
+
 
 plugins:
   - serverless-python-requirements

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -14,8 +14,6 @@ provider:
       - ${ssm:/naruhodoo/aws/security_group}
     subnetIds:
       - ${ssm:/naruhodoo/aws/subnet1}
-      - ${ssm:/naruhodoo/aws/subnet2}
-      - ${ssm:/naruhodoo/aws/subnet3}
       - ${ssm:/naruhodoo/aws/subnet4}
   environment:
     POSTGRES_HOST: ${ssm:/naruhodoo/${self:provider.stage}/postgres/host, env:POSTGRES_HOST}
@@ -26,6 +24,22 @@ provider:
     REDIS_HOST: ${ssm:/naruhodoo/${self:provider.stage}/redis/host, env:REDIS_HOST}
     REDIS_PORT: ${ssm:/naruhodoo/${self:provider.stage}/redis/port, env:REDIS_PORT}
     REDIS_DB: ${ssm:/naruhodoo/${self:provider.stage}/redis/db, env:REDIS_DB}
+  iam:
+    role:
+      statements:
+        - Effect: 'Allow'
+          Action:
+            - 'dynamodb:PutItem'
+            - 'dynamodb:DeleteItem'
+            - 'dynamodb:Scan'
+            - 'dynamodb:GetItem'
+          Resource:
+            - 'arn:aws:dynamodb:ap-northeast-2:401482569934:table/websocket-connections-jwlee-test'
+        - Effect: 'Allow'
+          Action:
+            - 'execute-api:ManageConnections'
+          Resource:
+            - 'arn:aws:execute-api:ap-northeast-2:401482569934:*/*/*/*'
 
 package:
   patterns:
@@ -57,6 +71,21 @@ functions:
       - http:
           path: /hello-db
           method: get
+  connect-handler:
+    handler: src/lambda/handler.connect_handler
+    events:
+      - websocket:
+          route: $connect
+  disconnect-handler:
+    handler: src/lambda/handler.disconnect_handler
+    events:
+      - websocket:
+          route: $disconnect
+  send-handler:
+    handler: src/lambda/handler.send_handler
+    events:
+      - websocket:
+          route: sendOpinion
 
 custom:
   customDomain:

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -86,6 +86,7 @@ functions:
     events:
       - websocket:
           route: sendOpinion
+    timeout: 29
 
 custom:
   customDomain:

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -86,7 +86,6 @@ functions:
     events:
       - websocket:
           route: sendOpinion
-    timeout: 29
 
 custom:
   customDomain:

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -81,6 +81,11 @@ functions:
     events:
       - websocket:
           route: $disconnect
+  init-join-handler:
+    handler: src/lambda/handler.init_join_handler
+    events:
+      - websocket:
+          route: initJoin
   send-handler:
     handler: src/lambda/handler.send_handler
     events:

--- a/backend/setup/dynamodb-create-table.sh
+++ b/backend/setup/dynamodb-create-table.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+aws dynamodb create-table \
+    --table-name ws-connections \
+    --attribute-definitions \
+        AttributeName=battleID,AttributeType=S \
+        AttributeName=connectionID,AttributeType=S \
+    --key-schema \
+        AttributeName=battleID,KeyType=HASH \
+        AttributeName=connectionID,KeyType=RANGE \
+    --provisioned-throughput \
+        ReadCapacityUnits=5,WriteCapacityUnits=5 \
+    --endpoint-url http://localhost:8000

--- a/backend/setup/model.sql
+++ b/backend/setup/model.sql
@@ -1,0 +1,65 @@
+CREATE TYPE "battle_status" AS ENUM ('BEFORE_OPEN', 'RUNNING', 'CLOSED');
+CREATE TYPE "opinion_status" AS ENUM ('CANDIDATE', 'PUBLISHED', 'DROPPED', 'REPORTED');
+CREATE TABLE "User" (
+  userId varchar(50) NOT NULL,
+  passwd bytea NOT NULL,
+  nickname varchar(50) NOT NULL,
+  profile varchar(50) NULL,
+  CONSTRAINT PK_USER_ID PRIMARY KEY (userId)
+);
+CREATE TABLE DiscussionBattle (
+  battleId varchar(6) NOT NULL,
+  ownerId varchar(50) NOT NULL,
+  title varchar(50) NOT NULL,
+  status battle_status NOT NULL,
+  visibility boolean NOT NULL,
+  switchChance boolean NOT NULL,
+  startTime timestamp NULL,
+  endTime timestamp NULL,
+  description varchar(100) NULL,
+  maxNoIfRounds integer NOT NULL,
+  maxNoVotes integer NOT NULL,
+  maxNoOfOpinion integer NOT NULL,
+  CONSTRAINT PK_DISCUSSION_BATTLE_ID PRIMARY KEY (battleId),
+  CONSTRAINT FK_8 FOREIGN KEY (ownerId) REFERENCES "User" (userId)
+);
+CREATE TABLE Round (
+  battleId VARCHAR(6) NOT NULL,
+  roundNo serial NOT NULL,
+  startTime timestamp NOT NULL,
+  endTime timestamp NULL,
+  description varchar(100) NULL,
+  CONSTRAINT PK_ROUND_ID PRIMARY KEY (battleId, roundNo),
+  CONSTRAINT FK_1 FOREIGN KEY (battleId) REFERENCES DiscussionBattle (battleId)
+);
+CREATE TABLE Opinion (
+  userId varchar(50) NOT NULL,
+  battleId varchar(6) NOT NULL,
+  roundNo serial NOT NULL,
+  "time" timestamp NOT NULL,
+  noOfLikes integer NOT NULL,
+  content varchar(150) NOT NULL,
+  status opinion_status NOT NULL,
+  CONSTRAINT PK_OPINION_ID PRIMARY KEY (userId, battleId, roundNo, "time"),
+  CONSTRAINT FK_2 FOREIGN KEY (battleId, roundNo) REFERENCES Round (battleId, roundNo),
+  CONSTRAINT FK_3 FOREIGN KEY (userId) REFERENCES "User" (userId)
+);
+CREATE TABLE Team (
+  teamId serial NOT NULL,
+  battleId varchar(6) NOT NULL,
+  name varchar(50) NOT NULL,
+  image bytea NOT NULL,
+  CONSTRAINT PK_TEAM_ID PRIMARY KEY (teamId),
+  CONSTRAINT FK_4 FOREIGN KEY (battleId) REFERENCES DiscussionBattle (battleId)
+);
+CREATE TABLE Support (
+  userId varchar(50) NOT NULL,
+  battleId varchar(6) NOT NULL,
+  roundNo serial NOT NULL,
+  vote serial NOT NULL,
+  "time" timestamp NOT NULL,
+  CONSTRAINT PK_SUPPORT_ID PRIMARY KEY (userId, battleId, roundNo),
+  CONSTRAINT FK_5 FOREIGN KEY (userId) REFERENCES "User" (userId),
+  CONSTRAINT FK_6 FOREIGN KEY (vote) REFERENCES Team (teamId),
+  CONSTRAINT FK_7 FOREIGN KEY (battleId, roundNo) REFERENCES Round (battleId, roundNo)
+);

--- a/backend/src/game/config.py
+++ b/backend/src/game/config.py
@@ -13,3 +13,10 @@ db_config = {
     "password": os.getenv("POSTGRES_PASSWORD"),
     "database": os.getenv("POSTGRES_DB")
 }
+
+dynamo_db_config = {
+    "service_name": "dynamodb",
+    "endpoint_url": os.getenv("DYNAMODB_ENDPOINT") if os.getenv("IS_OFFLINE") == "true" else None,
+}
+
+DYNAMODB_WS_CONNECTION_TABLE = os.getenv("DYNAMODB_WS_CONNECTION_TABLE")

--- a/backend/src/lambda/handler.py
+++ b/backend/src/lambda/handler.py
@@ -89,19 +89,11 @@ def disconnect_handler(event, context):
 def init_join_handler(event, context):
     connection_id = event['requestContext']['connectionId']
 
-    # 데이터를 header로 보내는 경우
-    headers = event['headers']
-    battle_id = headers['battleId']
-    nickname = headers['nickname']
-    user_id = headers['userId']
+    data = json.loads(event['body'])
+    battle_id = data['battleId']
+    nickname = data['nickname']
+    user_id = data['userId']
     team_id = ""
-    
-    # 데이터를 queryStringParameter로 보내는 경우
-    # parameters = event['queryStringParameters']
-    # battle_id = parameters['battleId']
-    # nickname = parameters['nickname']
-    # user_id = parameters['userId']
-    # team_id = ""
 
     # DynamoDB에 정보 등록
     dynamo_db.put_item(
@@ -116,7 +108,7 @@ def init_join_handler(event, context):
     )
 
     # 어떤 팀이 있는지 RDS에서 정보 가져오기
-    select_query = f"SELECT name FROM \"Team\" WHERE \"battleId\" = {battle_id}"
+    select_query = f"SELECT name FROM Team WHERE battleid = \'{battle_id}\'"
     psql_cursor.execute(select_query)
     rows = psql_cursor.fetchall()
     psql_cursor.close()
@@ -175,7 +167,7 @@ def send_handler(event, context):
     round, num_of_likes = json.loads(event['body'])['round'], 0
     status = "CANDIDATE"
 
-    insert_query = f'INSERT INTO \"Opinion\" VALUES ({user_id}, {battle_id}, {round}, {opinion_time}, {num_of_likes}, {opinion}, {status})'
+    insert_query = f'INSERT INTO Opinion VALUES (\'{user_id}\', \'{battle_id}\', {round}, {opinion_time}, {num_of_likes}, \'{opinion}\', \'{status}\')'
     psql_cursor.execute(insert_query)
     psql_ctx.client.commit()
     psql_cursor.close()

--- a/backend/src/lambda/handler.py
+++ b/backend/src/lambda/handler.py
@@ -1,7 +1,11 @@
 import json
 import platform
+import boto3
 
 from src.game import app
+
+
+dynamo_db = boto3.client('dynamodb')
 
 
 def hello(event, context):
@@ -38,3 +42,66 @@ def hello_db(event, context):
         "body": msg
     }
     return response
+
+
+def connect_handler(event, context):
+    connection_id = event['requestContext']['connectionId']
+    
+    query_parameters = event['queryStringParameters']
+    battle_id = query_parameters['battleId']
+    team_id = query_parameters['teamId']
+    nickname = query_parameters['nickname']
+    
+    # battleId, teamId, nickname
+    dynamo_db.put_item(
+        TableName="websocket-connections-jwlee-test",
+        Item={
+            'connection-ID': {'S': connection_id},
+            'battle-ID': {'S': battle_id},
+            'team-ID': {'S': team_id},
+            'nickname': {'S': nickname}
+        }
+    )
+    
+    return {'statusCode': 200, 'body': json.dumps({'message': "Clear"})}
+
+
+def disconnect_handler(event, context):
+    connection_id = event['requestContext']['connectionId']
+    
+    dynamo_db.delete_item(
+        TableName="websocket-connections-jwlee-test",
+        Key={'connection-ID': {'S': connection_id}}
+    )
+    
+    return {'statusCode': 200, 'body': json.dumps({'message': "Clear"})}
+
+
+def send_handler(event, context):
+    paginator = dynamo_db.get_paginator('scan')
+    connection_ids = []
+    for page in paginator.paginate(TableName="websocket-connections-jwlee-test"):
+        connection_ids.extend(page['Items'])
+
+    my_connection = event['requestContext']['connectionId']
+    my_info = dynamo_db.get_item(
+        TableName="websocket-connections-jwlee-test",
+        Key={"connection-ID": {"S": my_connection}}
+    )['Item']
+    
+    apigatewaymanagementapi = boto3.client(
+        'apigatewaymanagementapi',
+        endpoint_url=f"https://{event['requestContext']['domainName']}/{event['requestContext']['stage']}"
+    )
+    
+    opinion = json.loads(event['body'])['opinion']
+        
+    for connection in connection_ids:
+        other_connection = connection['connection-ID']['S']
+        if other_connection != my_info['connection-ID']['S'] and connection['battle-ID']['S'] == my_info['battle-ID']['S'] and connection['team-ID']['S'] == my_info['team-ID']['S']:
+            apigatewaymanagementapi.post_to_connection(
+                Data=opinion,
+                ConnectionId=other_connection
+            )
+        
+    return {'statusCode': 200, 'body': json.dumps({'message': "Clear"})}

--- a/backend/src/lambda/handler.py
+++ b/backend/src/lambda/handler.py
@@ -52,42 +52,67 @@ def connect_handler(event, context):
     team_id = query_parameters['teamId']
     nickname = query_parameters['nickname']
     
-    # battleId, teamId, nickname
     dynamo_db.put_item(
         TableName="websocket-connections-jwlee-test",
         Item={
-            'connection-ID': {'S': connection_id},
-            'battle-ID': {'S': battle_id},
-            'team-ID': {'S': team_id},
+            'connectionID': {'S': connection_id},
+            'battleID': {'S': battle_id},
+            'teamID': {'S': team_id},
             'nickname': {'S': nickname}
         }
     )
     
-    return {'statusCode': 200, 'body': json.dumps({'message': "Clear"})}
+    return {
+        'statusCode': 200,
+        'body': json.dumps({'message': "Add connection to DB"})
+    }
 
 
 def disconnect_handler(event, context):
     connection_id = event['requestContext']['connectionId']
+
+    # Find request user's battle id
+    response = dynamo_db.scan(
+        TableName="websocket-connections-jwlee-test",
+        FilterExpression="connectionID = :connection_id",
+        ExpressionAttributeValues={":connection_id": {"S": connection_id}},
+        ProjectionExpression="battleID,connectionID"
+    )['Items']
+    battle_id = response[0]['battleID']['S']
     
     dynamo_db.delete_item(
         TableName="websocket-connections-jwlee-test",
-        Key={'connection-ID': {'S': connection_id}}
+        Key={
+            'battleID': {'S': battle_id},
+            'connectionID': {'S': connection_id}
+        }
     )
     
-    return {'statusCode': 200, 'body': json.dumps({'message': "Clear"})}
+    return {
+        'statusCode': 200,
+        'body': json.dumps({'message': "Delete connection from DB"})
+    }
 
 
 def send_handler(event, context):
     paginator = dynamo_db.get_paginator('scan')
-    connection_ids = []
+    connections = []    # Contain all items in dynamodb table.
     for page in paginator.paginate(TableName="websocket-connections-jwlee-test"):
-        connection_ids.extend(page['Items'])
+        connections.extend(page['Items'])
 
-    my_connection = event['requestContext']['connectionId']
-    my_info = dynamo_db.get_item(
-        TableName="websocket-connections-jwlee-test",
-        Key={"connection-ID": {"S": my_connection}}
-    )['Item']
+    my_connection_id = event['requestContext']['connectionId']
+
+    # Find request user's connection information
+    my_info = None
+    for connection in connections:
+        if connection['connectionID']['S'] == my_connection_id:
+            my_info = connection
+            break
+    if my_info is None:
+        return {
+            'statusCode': 404,
+            'body': json.dumps({'message': "Cannot find your connection information"})
+        }
     
     apigatewaymanagementapi = boto3.client(
         'apigatewaymanagementapi',
@@ -95,13 +120,17 @@ def send_handler(event, context):
     )
     
     opinion = json.loads(event['body'])['opinion']
-        
-    for connection in connection_ids:
-        other_connection = connection['connection-ID']['S']
-        if other_connection != my_info['connection-ID']['S'] and connection['battle-ID']['S'] == my_info['battle-ID']['S'] and connection['team-ID']['S'] == my_info['team-ID']['S']:
+    
+    # Broadcast user's opinion to same team.
+    for connection in connections:
+        other_connection = connection['connectionID']['S']
+        if other_connection != my_info['connectionID']['S'] and connection['battleID']['S'] == my_info['battleID']['S'] and connection['teamID']['S'] == my_info['teamID']['S']:
             apigatewaymanagementapi.post_to_connection(
                 Data=opinion,
                 ConnectionId=other_connection
             )
         
-    return {'statusCode': 200, 'body': json.dumps({'message': "Clear"})}
+    return {
+        'statusCode': 200,
+        'body': json.dumps({'message': "Post your opinion to your team"})
+    }

--- a/backend/src/lambda/handler.py
+++ b/backend/src/lambda/handler.py
@@ -10,6 +10,9 @@ from src.utility.context import PostgresContext
 
 
 dynamo_db = boto3.client('dynamodb')
+psql_ctx = PostgresContext(os.getenv("POSTGRES_HOST"), os.getenv("POSTGRES_PORT"), os.getenv("POSTGRES_USER"),
+                               os.getenv("POSTGRES_PASSWORD"), os.getenv("POSTGRES_DB"))
+psql_cursor = psql_ctx.cursor
 
 
 def hello(event, context):
@@ -49,28 +52,11 @@ def hello_db(event, context):
 
 
 def connect_handler(event, context):
-    connection_id = event['requestContext']['connectionId']
-    
-    headers = event['headers']
-    battle_id = headers['battleId']
-    nickname = headers['nickname']
-    email = headers['email']
-    team_id = ""
-    
-    dynamo_db.put_item(
-        TableName="websocket-connections-jwlee-test",
-        Item={
-            'connectionID': {'S': connection_id},
-            'battleID': {'S': battle_id},
-            'teamID': {'S': team_id},
-            'nickname': {'S': nickname},
-            'email': {'S': email}
-        }
-    )
-    
+    # 기존에 원스텝이었던 것을 투스텝으로 쪼개자.
+    # 여기서는 말 그대로 websocket 길만 뚫어준다.
     return {
         'statusCode': 200,
-        'body': json.dumps({'message': "Add connection to DB"})
+        'body': json.dumps({"message": "Connect Success"})
     }
 
 
@@ -100,17 +86,63 @@ def disconnect_handler(event, context):
     }
 
 
+def init_join_handler(event, context):
+    connection_id = event['requestContext']['connectionId']
+
+    # 데이터를 header로 보내는 경우
+    headers = event['headers']
+    battle_id = headers['battleId']
+    nickname = headers['nickname']
+    user_id = headers['userId']
+    team_id = ""
+    
+    # 데이터를 queryStringParameter로 보내는 경우
+    # parameters = event['queryStringParameters']
+    # battle_id = parameters['battleId']
+    # nickname = parameters['nickname']
+    # user_id = parameters['userId']
+    # team_id = ""
+
+    # DynamoDB에 정보 등록
+    dynamo_db.put_item(
+        TableName="websocket-connections-jwlee-test",
+        Item={
+            'connectionID': {'S': connection_id},
+            'battleID': {'S': battle_id},
+            'teamID': {'S': team_id},
+            'userID': {'S': user_id},
+            'nickname': {'S': nickname}
+        }
+    )
+
+    # 어떤 팀이 있는지 RDS에서 정보 가져오기
+    select_query = f"SELECT name FROM \"Team\" WHERE \"battleId\" = {battle_id}"
+    psql_cursor.execute(select_query)
+    rows = psql_cursor.fetchall()
+    psql_cursor.close()
+    team_names = [row for row in rows]
+
+    return {
+        'statusCode': 200,
+        'body': json.dumps({
+            'message': 'Join Request Success',
+            'teams': team_names
+        })
+    }
+
+
 def send_handler(event, context):
     opinion_time = datetime.fromtimestamp(time.time())
     
+    # DynamoDB의 모든 값을 얻어온다.
     paginator = dynamo_db.get_paginator('scan')
-    connections = []    # Contain all items in dynamodb table.
+    connections = []
     for page in paginator.paginate(TableName="websocket-connections-jwlee-test"):
         connections.extend(page['Items'])
 
     my_connection_id = event['requestContext']['connectionId']
 
-    # Find request user's connection information
+    # 사용자의 connection 정보를 찾는다.
     my_info = None
     for connection in connections:
         if connection['connectionID']['S'] == my_connection_id:
@@ -127,28 +159,26 @@ def send_handler(event, context):
         endpoint_url=f"https://{event['requestContext']['domainName']}/{event['requestContext']['stage']}"
     )
     
+    # 같은 팀에게 자신의 의견을 broadcasting 한다.
     opinion = json.loads(event['body'])['opinion']
-    
-    # Broadcast user's opinion to same team.
+    user_id, battle_id, team_id, nickname = my_info['userID']['S'], my_info['battleID']['S'], my_info['teamID']['S'], my_info['nickname']['S']
     for connection in connections:
         other_connection = connection['connectionID']['S']
-        if connection['battleID']['S'] == my_info['battleID']['S'] and connection['teamID']['S'] == my_info['teamID']['S']:
+        if connection['battleID']['S'] == battle_id and connection['teamID']['S'] == team_id:
             apigatewaymanagementapi.post_to_connection(
-                Data=my_info['nickname']['S'] + ": " + opinion,
+                Data=nickname + ": " + opinion,
                 ConnectionId=other_connection
             )
 
     # PK: userId, battleId, roundNo, time
     # extra fields: noOfLikes, content, status
     round, num_of_likes = json.loads(event['body'])['round'], 0
-    status = "common"
+    status = "CANDIDATE"
 
-    psql_ctx = PostgresContext(os.getenv("POSTGRES_HOST"), os.getenv("POSTGRES_PORT"), os.getenv("POSTGRES_USER"),
-                               os.getenv("POSTGRES_PASSWORD"), os.getenv("POSTGRES_DB"))
-    psql_cursor = psql_ctx.cursor
-    insert_query = f'INSERT INTO Opinion VALUES (\'75ead7fc-6f61-4a3e-839b-fb3642a2ad64\', \'75ead7fc-6f61-4a3e-839b-fb3642a2ad64\', {round}, \'{opinion_time}\', {num_of_likes}, \'{opinion}\', \'{status}\')'
+    insert_query = f'INSERT INTO \"Opinion\" VALUES ({user_id}, {battle_id}, {round}, {opinion_time}, {num_of_likes}, {opinion}, {status})'
     psql_cursor.execute(insert_query)
     psql_ctx.client.commit()
+    psql_cursor.close()
 
     return {
         'statusCode': 200,

--- a/backend/src/lambda/handler.py
+++ b/backend/src/lambda/handler.py
@@ -50,11 +50,11 @@ def hello_db(event, context):
 def connect_handler(event, context):
     connection_id = event['requestContext']['connectionId']
     
-    query_parameters = event['queryStringParameters']
-    battle_id = query_parameters['battleId']
-    team_id = query_parameters['teamId']
-    nickname = query_parameters['nickname']
-    email = query_parameters['email']
+    headers = event['headers']
+    battle_id = headers['battleId']
+    team_id = headers['teamId']
+    nickname = headers['nickname']
+    email = headers['email']
     
     dynamo_db.put_item(
         TableName="websocket-connections-jwlee-test",
@@ -100,6 +100,8 @@ def disconnect_handler(event, context):
 
 
 def send_handler(event, context):
+    opinion_time = time.time()
+    
     paginator = dynamo_db.get_paginator('scan')
     connections = []    # Contain all items in dynamodb table.
     for page in paginator.paginate(TableName="websocket-connections-jwlee-test"):
@@ -124,7 +126,7 @@ def send_handler(event, context):
         endpoint_url=f"https://{event['requestContext']['domainName']}/{event['requestContext']['stage']}"
     )
     
-    opinion = json.loads(event['body'])['opinion']
+    opinion = my_info['nickname']['S'] + ": " + json.loads(event['body'])['opinion']
     
     # Broadcast user's opinion to same team.
     for connection in connections:
@@ -139,7 +141,6 @@ def send_handler(event, context):
     # extra fields: noOfLikes, content, status
     round, num_of_likes = json.loads(event['body'])['round'], 0
     status = "common"
-    opinion_time = time.time()
 
     psql_ctx = PostgresContext("172.18.0.3", os.getenv("POSTGRESQL_PORT"), os.getenv("POSTGRESQL_USER"),
                                os.getenv("POSTGRESQL_PASSWORD"), os.getenv("POSTGRESQL_DB"))

--- a/backend/src/lambda/handler.py
+++ b/backend/src/lambda/handler.py
@@ -1,8 +1,11 @@
 import json
 import platform
+import os
+import time
 import boto3
 
 from src.game import app
+from src.utility.context import PostgresContext
 
 
 dynamo_db = boto3.client('dynamodb')
@@ -51,6 +54,7 @@ def connect_handler(event, context):
     battle_id = query_parameters['battleId']
     team_id = query_parameters['teamId']
     nickname = query_parameters['nickname']
+    email = query_parameters['email']
     
     dynamo_db.put_item(
         TableName="websocket-connections-jwlee-test",
@@ -58,7 +62,8 @@ def connect_handler(event, context):
             'connectionID': {'S': connection_id},
             'battleID': {'S': battle_id},
             'teamID': {'S': team_id},
-            'nickname': {'S': nickname}
+            'nickname': {'S': nickname},
+            'email': {'S': email}
         }
     )
     
@@ -124,12 +129,26 @@ def send_handler(event, context):
     # Broadcast user's opinion to same team.
     for connection in connections:
         other_connection = connection['connectionID']['S']
-        if other_connection != my_info['connectionID']['S'] and connection['battleID']['S'] == my_info['battleID']['S'] and connection['teamID']['S'] == my_info['teamID']['S']:
+        if connection['battleID']['S'] == my_info['battleID']['S'] and connection['teamID']['S'] == my_info['teamID']['S']:
             apigatewaymanagementapi.post_to_connection(
                 Data=opinion,
                 ConnectionId=other_connection
             )
-        
+
+    # PK: userId, battleId, roundNo, time
+    # extra fields: noOfLikes, content, status
+    round, num_of_likes = json.loads(event['body'])['round'], 0
+    status = "common"
+    opinion_time = time.time()
+
+    psql_ctx = PostgresContext("172.18.0.3", os.getenv("POSTGRESQL_PORT"), os.getenv("POSTGRESQL_USER"),
+                               os.getenv("POSTGRESQL_PASSWORD"), os.getenv("POSTGRESQL_DB"))
+    psql_cursor = psql_ctx.cursor
+    # Or getting email from Postgres Database?
+    insert_query = f"INSERT INTO Opinion VALUES (\'{my_info['email']['S']}\', \'{my_info['battleID']['S']}\', {round}, {opinion_time}, {num_of_likes}, \'{opinion}\', \'{status}\')"
+    psql_cursor.execute(insert_query)
+    psql_ctx.client.commit()
+
     return {
         'statusCode': 200,
         'body': json.dumps({'message': "Post your opinion to your team"})

--- a/backend/src/utility/context.py
+++ b/backend/src/utility/context.py
@@ -35,8 +35,10 @@ class PostgresContext:
             password=self.password,
             database=self.database
         )
+        self.cursor = self.client.cursor()
     
     def __del__(self):
+        self.cursor.close()
         self.client.close()
 
     def __enter__(self):

--- a/backend/src/utility/context.py
+++ b/backend/src/utility/context.py
@@ -38,7 +38,6 @@ class PostgresContext:
         self.cursor = self.client.cursor()
     
     def __del__(self):
-        self.cursor.close()
         self.client.close()
 
     def __enter__(self):

--- a/backend/src/utility/decorator.py
+++ b/backend/src/utility/decorator.py
@@ -1,0 +1,13 @@
+import functools
+
+
+def cors(func):
+    @functools.wraps(func)
+    def wrapper(event, context):
+        response = func(event, context)
+        if 'headers' not in response:
+            response['headers'] = {}
+        response['headers']['Access-Control-Allow-Origin'] = '*'
+        response['headers']['Access-Control-Allow-Credentials'] = True
+        return response
+    return wrapper

--- a/backend/src/utility/websocket.py
+++ b/backend/src/utility/websocket.py
@@ -1,0 +1,39 @@
+import functools
+import json
+import os
+
+import boto3
+
+
+class WebSocketClient:
+    def __init__(self, api_endpoint):
+        self._api_endpoint = api_endpoint
+        self._client = boto3.client('apigatewaymanagementapi', endpoint_url=self._api_endpoint)
+
+    def send(self, connection_id, data):
+        try:
+            self._client.post_to_connection(
+                ConnectionId=connection_id,
+                Data=json.dumps(data).encode('utf-8')
+            )
+        except:
+            print(f"Failed to send message to connection {connection_id}")
+
+    def broadcast(self, connection_ids, payload):
+        for connection_id in connection_ids:
+            self.send(connection_id, payload)
+    
+
+
+def wsclient(func):
+    functools.wraps(func)
+    def wrapper(event, context):
+        if os.environ.get('IS_OFFLINE') == 'true':
+            ws_endpoint = "http://localhost:3001"
+        else:
+            ws_endpoint = f"https://{event['requestContext']['domainName']}/{event['requestContext']['stage']}"
+
+        wsclient = WebSocketClient(ws_endpoint)
+        return func(event, context, wsclient)
+
+    return wrapper

--- a/backend/test/utility/test_utility.py
+++ b/backend/test/utility/test_utility.py
@@ -1,9 +1,10 @@
+import boto3
 import psycopg2
 import pytest
 from redis import Redis
 
 from src.utility.context import RedisContext
-from src.game.config import redis_config, db_config
+from src.game.config import *
 
 from logging import getLogger
 
@@ -23,6 +24,11 @@ def redis() -> Redis:
     yield ctx.client
     ctx.client.close()
 
+@pytest.fixture
+def dynamo_db():
+    client = boto3.resource(**dynamo_db_config)
+    yield client
+
 
 def test_redis_get_client(redis):
     my_client = redis.client_info()
@@ -31,3 +37,7 @@ def test_redis_get_client(redis):
 
 def test_psycopg2_connection(db):
     assert db is not None, "Psycopg2 Connection Failed"
+
+
+def test_dynamodb_connection(dynamo_db):
+    assert dynamo_db is not None, "DynamoDB Connection Failed"


### PR DESCRIPTION
이 PR은 #32 이슈에 대해 구현했습니다.  
WebSocket을 통해 처음 room에 접속하면 room에 있는 team 이름들을 WebSocket 메시지를 통해 얻을 수 있습니다.  
또한 의견을 보낼 때 본인과 같은 팀원들에게 broadcasting 됩니다. 작성한 의견은 AWS RDS(PostgreSQL DB)에 저장됩니다.  
현재 구현 사항은 _jwlee_ 스테이지에 배포가 된 상태입니다. WebSocket 통신에 사용하는 API Gateway 주소는 jwlee-serverless-naruhodoo-websockets 에서 확인할 수 있습니다.

# 테스트 전
기능 테스트를 위해 임의의 유저를 생성하고 유저 정보로 접속을 진행할 것입니다. 이를 위해 임의의 유저 등의 정보들을 DB에 저장해야 합니다. 테스트 하면서 직접 정보들을 추가하면서 할 수 있고, 기존에 존재하는 정보들을 이용해 확인할 수 있습니다.  
# 테스트 방법
1. Postman, wscat 등 WebSocket을 테스트 할 수 있는 도구를 사용합니다.
2. 위에 있는 API Gateway에 연결합니다. 연결이 정상적으로 되는지 확인합니다. 그리고 DynamoDB에 connection 정보가 저장됐는지 확인합니다.
3. 아래와 같이 데이터를 보냅니다. 이를 통해 team 테이블의 값이 반환되는지 확인합니다.
```json
{
  "action": "initJoin",
  "battleId": <배틀 아이디 값>,
  "userId": <유저 아이디(이메일 형식)>,
  "nickname": <유저 닉네임>
}
```
4. 아래와 같이 데이터를 보냅니다. 이를 통해 본인(여러 개를 접속해서 할 때 접속한 모든 유저)에게 의견이 broadcasting 되는지 확인합니다. 그리고 opinion 테이블에 작성한 의견이 저장됐는지 확인합니다.
```json
{
  "action": "sendOpinion",
  "round": <라운드 넘버>,
  "opinion": <유저의 의견>
}
```