### PR TITLE
refactor: Insert query in send-handler

### DIFF
--- a/backend/src/lambda/handler.py
+++ b/backend/src/lambda/handler.py
@@ -172,6 +172,14 @@ def send_handler(event, context, wsclient):
                 psql_cursor.execute(insert_query)
                 psql_ctx.commit()
     except fk_violation:
+        wsclient.send(
+                connection_id=my_connection_id,
+                data={
+                    "action": "recvOpinion",
+                    "nickname": "MASTER",
+                    "opinion": "You send malformed data."
+                }
+            )
         return {
             'statusCode': 400,
             'body': 'You tried insert malformed data into DB'

--- a/backend/src/lambda/handler.py
+++ b/backend/src/lambda/handler.py
@@ -114,7 +114,7 @@ def init_join_handler(event, context, wsclient):
     # 어떤 팀이 있는지 RDS에서 정보 가져오기
     with PostgresContext(**config.db_config) as psql_ctx:
         with psql_ctx.cursor() as psql_cursor:
-            select_query = f"SELECT teamid, name FROM team WHERE battleid = \'{battle_id}\'"
+            select_query = f"SELECT \"teamId\", name FROM \"Team\" WHERE \"battleId\" = \'{battle_id}\'"
             psql_cursor.execute(select_query)
             rows = psql_cursor.fetchall()
             team_names = [{"teamId": row[0], "teamName": row[1]} for row in rows]
@@ -168,7 +168,7 @@ def send_handler(event, context, wsclient):
     try:
         with PostgresContext(**config.db_config) as psql_ctx:
             with psql_ctx.cursor() as psql_cursor:
-                insert_query = f'INSERT INTO Opinion (userid, battleid, roundno, nooflikes, content, \"time\", status) VALUES (\'{user_id}\', \'{battle_id}\', {round}, {num_of_likes}, \'{opinion}\', \'{opinion_time}\', \'{status}\')'
+                insert_query = f'INSERT INTO \"Opinion\" (\"userId\", \"battleId\", \"roundNo\", \"noOfLikes\", \"content\", \"time\", status) VALUES (\'{user_id}\', \'{battle_id}\', {round}, {num_of_likes}, \'{opinion}\', \'{opinion_time}\', \'{status}\')'
                 psql_cursor.execute(insert_query)
                 psql_ctx.commit()
     except fk_violation:
@@ -235,7 +235,7 @@ def vote_handler(event, context, wsclient):
     # 팀 이름을 찾기 위한 SQL문 실행
     with PostgresContext(**config.db_config) as psql_ctx:
         with psql_ctx.cursor() as psql_cursor:
-            select_query = f"SELECT name FROM team WHERE battleid = \'{battle_id}\' and teamid = \'{team_id}\'"
+            select_query = f"SELECT name FROM \"Team\" WHERE \"battleId\" = \'{battle_id}\' and \"teamId\" = \'{team_id}\'"
             psql_cursor.execute(select_query)
             row = psql_cursor.fetchall()
             team_name = row[0][0]
@@ -255,7 +255,7 @@ def vote_handler(event, context, wsclient):
     round = json.loads(event['body'])['round']
     with PostgresContext(**config.db_config) as psql_ctx:
         with psql_ctx.cursor() as psql_cursor:
-            insert_query = f'INSERT INTO Support VALUES (\'{user_id}\', \'{battle_id}\', {round}, {team_id}, \'{vote_time}\')'
+            insert_query = f'INSERT INTO \"Support\" VALUES (\'{user_id}\', \'{battle_id}\', {round}, {team_id}, \'{vote_time}\')'
             psql_cursor.execute(insert_query)
             psql_ctx.commit()
 

--- a/backend/src/lambda/handler.py
+++ b/backend/src/lambda/handler.py
@@ -180,7 +180,7 @@ def send_handler(event, context, wsclient):
 
     with PostgresContext(**config.db_config) as psql_ctx:
         with psql_ctx.cursor() as psql_cursor:
-            insert_query = f'INSERT INTO Opinion VALUES (\'{user_id}\', \'{battle_id}\', {round}, \'{opinion_time}\', {num_of_likes}, \'{opinion}\', \'{status}\')'
+            insert_query = f'INSERT INTO Opinion VALUES (\'{user_id}\', \'{battle_id}\', {round}, {num_of_likes}, \'{opinion}\', \'{opinion_time}\', \'{status}\')'
             psql_cursor.execute(insert_query)
             psql_ctx.commit()
 


### PR DESCRIPTION
#56 PR로 인해 생긴 변경 사항에 대한 PR입니다.  
Opinion 테이블의 "time" 컬럼의 위치 변경 및 "order" 컬럼 추가에 따라 insert query에 약간의 변동이 생겼습니다.  
이것 이외로 dev 브랜치에 있는 핸들러 함수들 중 #56 PR로 인한 side effect 없습니다.
(2022.04.28)  
#61 PR로 인해 전체적인 WebSocket 람다 함수에서 사용된 쿼리들을 수정했습니다.  
(2022.04.29)  
추가적으로 용준 님이 보여준 오류에 대한 핸들링 방법을 _send-handler_ , _vote-handler_ 에 적용했습니다.  