### PR TITLE
Feat: Add local DynamoDB for local dev environment

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -30,6 +30,7 @@ services:
   dynamodb:
     image: amazon/dynamodb-local:latest
     container_name: dynamodb
+    user: root
     restart: always
     ports:
       - 8000:8000

--- a/backend/setup/dynamodb-create-table.sh
+++ b/backend/setup/dynamodb-create-table.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-aws dynamodb create-table \
+aws dynamodb --endpoint-url http://localhost:8000 \
+    create-table \
     --table-name ws-connections \
     --attribute-definitions \
         AttributeName=battleID,AttributeType=S \


### PR DESCRIPTION
해당 PR은 기존에 존재하던 local DynamoDB 컨테이너를 사용하기 위한 PR입니다.

📝 변경사항 요약
- `docker-compose.yml` 에 dynamodb 항목으로 user를 추가했습니다.
- `dynamodb-create-table.sh` 에 엔드포인트를 localhost로 지정했습니다.

🤔 지금까지 사용하지 못 한 이유는?
지금까지 dynamodb를 로컬 환경에서 못 쓴 이유는 알아보니 **권한 문제**였습니다. 따라서 유저를 root로 만들어 권한문제를 해결했고 테이블을 생성하는 스크립트에는 Endpoint를 localhost로 설정해서 각자의 로컬에 존재하는 DynamoDB를 대상으로 적용하게끔 만들었습니다.

API 테스트도 한번 해보았는데 @Jaewook-Lee 님이 만드신 투표 기능은 잘 되지만 의견 보내기 기능은 작동하지 않습니다. 이유는 현재 프로젝트 저장소의 DDL 스펙을 바꿨는데 현재 투표 기능은 AWS 배포 중인 PostgreSQL DB를 기준으로 작성되어 인스턴스 생성문의 스펙이 바뀐 스펙에 부합하지 않아서 에러가 납니다.

⚒️ DynamoDB 관련 좋은 툴은 없는 건가?
현재로서는 찾아보니 좋은 툴이 없더군요. 저희가 지금 사용하는 방식이 DB를 컨테이너에 띄우는 방식이라서 별도의 클라이언트를 깔아도 인식을 못 합니다. 이는 AWS Workbench도 해당되는 사항입니다. 따라서 값을 추적하거나 DB에 변경을 가하려면 그냥 aws-cli를 사용하셔야 합니다.
아니면 python의 `boto3` 모듈을 이용해서 직접 클라이언트를 구현하는 방법도 있지만 시간이 많이 걸리는 일입니다.

💁🏻‍♂️ 자잘한 팁
- 로컬에 있는 DynamoDB의 테이블 내용을 확인하는 방법 : `aws dynamodb --endpoint-url http://localhost:[포트번호] scan --table-name [테이블 이름(기본은 ws-connections)]`
- 로컬 환경에서 테스트 할 때는 가급적 `docker compose up`을 <ins>foreground로 실행시키고 있는 터미널을 하나 준비하는게 좋습니다</ins>. 컨테이너에 관련된 로그가 계속 출력되기 때문에 뭐가 문제인지 금방 파악 가능합니다.

해당 내용은 주로 백엔드의 이야기이지만 모두가 로컬 개발환경 구축이 끝났다는 걸 알았으면 합니다.