### PR TITLE
Feat: Like opinion

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -114,6 +114,11 @@ functions:
     events:
       - websocket:
           route: vote
+  like-handler:
+    handler: src/lambda/handler.like_handler
+    events:
+      - websocket:
+          route: like
 
 custom:
   customDomain:

--- a/backend/src/lambda/handler.py
+++ b/backend/src/lambda/handler.py
@@ -275,3 +275,78 @@ def vote_handler(event, context, wsclient):
         'body': 'Vote Success'
     }
     return response
+
+@wsclient
+def like_handler(event, context, wsclient):
+    connection_id = event['requestContext']['connectionId']
+
+    # DynamoDB에서 유저 정보 찾기
+    response = dynamo_db.scan(
+        TableName=config.DYNAMODB_WS_CONNECTION_TABLE,
+        FilterExpression="connectionID = :connection_id",
+        ExpressionAttributeValues={":connection_id": {"S": connection_id}},
+        ProjectionExpression="battleID,connectionID,nickname,userID"
+    )['Items']
+    
+    
+    battle_id = response[0]['battleID']['S']
+    user_id = json.loads(event['body'])['userId']
+    order = json.loads(event['body'])['opinionNo']
+    round = json.loads(event['body'])['round']
+    
+    # Opinion 테이블에서 해당 의견의 좋아요 수를 1증가 시킨다.
+    # Race condition이 있기 때문에 쿼리를 동기화 해야한다.
+    try:
+        with PostgresContext(**config.db_config) as psql_ctx:
+            with psql_ctx.cursor() as psql_cursor:
+                psql_cursor.execute("BEGIN")
+                psql_cursor.execute(f'SELECT "noOfLikes" FROM "Opinion" WHERE "userId" = \'{user_id}\' AND "battleId" = \'{battle_id}\' AND "roundNo" = {round} AND "order" = {order} FOR UPDATE;')
+                row = psql_cursor.fetchone()      
+                likes = row[0]
+                psql_cursor.execute(f'UPDATE "Opinion" SET "noOfLikes" = {likes + 1} WHERE "userId" = \'{user_id}\' AND "battleId" = \'{battle_id}\' AND "roundNo" = {round} AND "order" = {order}')
+                psql_cursor.execute("COMMIT;")
+    except:
+        wsclient.send(
+            connection_id=connection_id,
+            data={
+                "action": "likeResult",
+                "result": "fail",
+                "opinionNo": order,
+                "noOfLikes": "None"
+            }
+        )
+
+        response = {
+            'statusCode': 400,
+            'body': 'Like Fail'
+        }
+        return response
+    
+    # Opinion 테이블에서 해당 의견의 좋아요 수를 가져온다.
+    with PostgresContext(**config.db_config) as psql_ctx:
+        with psql_ctx.cursor() as psql_cursor:
+            select_query = f"""
+                SELECT "noOfLikes"
+                FROM "Opinion"
+                WHERE "userId" = '{user_id}' AND "battleId" = '{battle_id}' AND "roundNo" = {round} AND "order" = {order}
+            """
+            psql_cursor.execute(select_query)
+            row = psql_cursor.fetchall()
+            no_of_likes = row[0][0]
+    
+    # Response 전송
+    wsclient.send(
+        connection_id=connection_id,
+        data={
+            "action": "likeResult",
+            "result": "success",
+            "opinionNo": order,
+            "noOfLikes": no_of_likes
+        }
+    )
+
+    response = {
+        'statusCode': 200,
+        'body': 'Like Success'
+    }
+    return response


### PR DESCRIPTION
해당 PR은 #60 을 해결하기 위한 PR입니다.

전제조건
- 해당 기능은 @Jaewook-Lee 님이 만드신 `initJoin` 액션을 무사히 수행한 뒤에 실행하는 것을 가정합니다.

Request Form
```bash
{
    "action": "like",
    "userId": "<유저 ID>",
    "round": <현재 라운드>,
    "opinionNo": <해당 의견 order>
}
```
Response Form
```bash
{
    "action": "likeResult",
    "result": "success",
    "opinionNo": <해당 의견 order>,
    "noOfLikes": <이번 좋아요가 반영된 전체 좋아요수>
}
```

**고민거리 및 주의사항**
1. 해당 기능의 경우 현재 refresh 타임 때, 일괄적으로 프론트에서 호출된다고 가정하고 작성하였습니다. 그러나 저번 회의에서 Opinion 상태를 바꾸는 별도의 람다 함수가 time을 기준으로 계속 실행되고 있다고 했기 때문에 실시간으로 이 기능을 호출 가능하게끔 바꾸는게 더 좋을지 살짝 고민입니다. -> 만약 실시간이 된다면 unlike 기능도 추가되어야 합니다.
2. Like 기능은 위에서 말한 호출 시점과 관계 없이 유저 간에 <ins>경쟁 조건이 발생할 수 있습니다</ins>. 따라서 동기화를 시키는 코드를 적용했습니다만, 시나리오 테스트에 대해서는 검증이 되질 않았습니다. 해당 부분에 대해서는 테스트를 해주시고 피드백을 해주시면 좋을 것 같습니다.