### PR TITLE
feat: finish battle

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -35,7 +35,6 @@ services:
     restart: always
     ports:
       - 8000:8000
-    user: root
     volumes:
       - ./volumes/dynamodb-data:/data
     command: "-jar DynamoDBLocal.jar -sharedDb -dbPath /data"

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -97,12 +97,12 @@ functions:
         handler: src/lambda/handler.connect_handler
         events:
             - websocket:
-                  route: $connect
+                route: $connect
     disconnect-handler:
         handler: src/lambda/handler.disconnect_handler
         events:
             - websocket:
-                  route: $disconnect
+                route: $disconnect
     init-join-handler:
         handler: src/lambda/handler.init_join_handler
         events:
@@ -112,42 +112,42 @@ functions:
         handler: src/lambda/handler.send_handler
         events:
             - websocket:
-                  route: sendOpinion
+                route: sendOpinion
     get-battles-handler:
         handler: src/lambda/handler.get_battles
         events:
             - websocket:
-                  route: getBattles
+                route: getBattles
     create-battles-handler:
         handler: src/lambda/handler.create_battle
         events:
             - websocket:
-                  route: createBattle
+                route: createBattle
     get-battle-handler:
         handler: src/lambda/handler.get_battle
         events:
             - websocket:
-                  route: getBattle
+                route: getBattle
     start-battle-handler:
         handler: src/lambda/handler.start_battle
         events:
             - websocket:
-                  route: startBattle
+                route: startBattle
     end-battle-handler:
         handler: src/lambda/handler.end_battle
         events:
             - websocket:
-                  route: endBattle
+                route: endBattle
     start-round-handler:
         handler: src/lambda/handler.start_round
         events:
             - websocket:
-                  route: startRound
+                route: startRound
     end-round-handler:
         handler: src/lambda/handler.end_round
         events:
             - websocket:
-                  route: endRound
+                route: endRound
     vote-handler:
         handler: src/lambda/handler.vote_handler
         events:
@@ -157,8 +157,13 @@ functions:
         handler: src/lambda/handler.preparation_start_handler
         events:
             - websocket:
-                  route: preparationStart
+                route: preparationStart
         timeout: 100
+    finish-battle-handler:
+        handler: src/lambda/handler.finish_battle_handler
+        events:
+            - websocket:
+                route: finishBattle
 
 custom:
     customDomain:

--- a/backend/src/game/app.py
+++ b/backend/src/game/app.py
@@ -749,3 +749,7 @@ def end_round(event, context, wsclient):
                 "Error": str(e)
             })
         }
+
+
+def finish_battle_handler(event, context, wsclinet):
+    pass

--- a/backend/src/game/app.py
+++ b/backend/src/game/app.py
@@ -767,7 +767,7 @@ def finish_battle_handler(event, context, wsclient):
 
     select_query = f"SELECT \"vote\", COUNT(\"vote\") FROM \"Support\" WHERE \"battleId\" = \'{my_battle_id}\' and \"roundNo\" = {max_rounds} GROUP BY \"vote\""
     rows = psql_ctx.execute_query(select_query)
-    return_obj = json.dumps({str(team_id): vote_cnt for team_id, vote_cnt in rows})
+    return_obj = {str(team_id): vote_cnt for team_id, vote_cnt in rows}
 
     for connection in connections:
         wsclient.send(

--- a/backend/src/game/app.py
+++ b/backend/src/game/app.py
@@ -752,4 +752,13 @@ def end_round(event, context, wsclient):
 
 
 def finish_battle_handler(event, context, wsclinet):
-    pass
+    my_battle_id = json.loads(event['body'])['battleId']
+    select_query = f"SELECT \"maxNoOfRounds\" FROM \"DiscussionBattle\" WHERE \"battleId\" = \'{my_battle_id}\'"
+    row = psql_ctx.execute_query(select_query)
+    max_rounds = row[0][0]
+    
+    response = {
+        'stautsCode': 200,
+        'body': 'Getting Final Result Success'
+    }
+    return response

--- a/backend/src/game/app.py
+++ b/backend/src/game/app.py
@@ -756,6 +756,10 @@ def finish_battle_handler(event, context, wsclinet):
     select_query = f"SELECT \"maxNoOfRounds\" FROM \"DiscussionBattle\" WHERE \"battleId\" = \'{my_battle_id}\'"
     row = psql_ctx.execute_query(select_query)
     max_rounds = row[0][0]
+
+    select_query = f"SELECT \"vote\", COUNT(\"vote\") FROM \"Support\" WHERE \"battleId\" = \'{my_battle_id}\' and \"roundNo\" = {max_rounds} GROUP BY \"vote\""
+    rows = psql_ctx.execute_query(select_query)
+    print(rows)
     
     response = {
         'stautsCode': 200,

--- a/backend/src/lambda/handler.py
+++ b/backend/src/lambda/handler.py
@@ -190,3 +190,8 @@ def like_handler(event, context, wsclient):
         'body': 'Like Success'
     }
     return response
+
+
+@wsclient
+def finish_battle_handler(event, context, wsclient):
+    return app.finish_battle_handler(event, context, wsclient)


### PR DESCRIPTION
이 PR은 #65  이슈를 구현했습니다.  
WebSocket을 통해 토론의 최종 결과를 얻는 기능을 수행할 수 있습니다.  

# 테스트 전
 __Support__ 테이블에 충분한 양의 투표 기록들이 있어야 합니다. 로컬 테스트에서 사용했던 테이블 내용은 아래의 csv 파일로 공유합니다.  
[Support_Table.csv](https://github.com/kookmin-sw/capstone-2023-05/files/11452985/Support_Table.csv)_(23.05.11에 파일이 수정됐습니다.)_  

그리고 테스트를 위해 최소 1명의 토론 참가자가 _initJoin_ 과정을 무사히 수행해야 합니다.  
# 테스트 방법
1. 연결한 connection에서 _finishBattle_ 액션을 요청합니다.  
![스크린샷 2023-05-10 23-49-28](https://github.com/kookmin-sw/capstone-2023-05/assets/39159921/d8552d1b-75b0-4afc-ba13-cae2c6856928)
2. 연결된 모든 참가자에게 websocket 메세지가 전송되는지 확인합니다.  
테스트가 성공적이라면 아래와 같은 메세지들을 받아야 합니다.
```json
{
    "action": "getFinalResult",
    "result": {
        "1": 1,
        "2": 3
    }
}
```
위에 작성한 예시 결과는 위에 공유한 파일을 바탕으로 나오는 결과입니다.  