### PR TITLE
refactor: vote-handler

### DIFF
--- a/backend/src/game/app.py
+++ b/backend/src/game/app.py
@@ -204,8 +204,9 @@ def vote_handler(event, context, wsclient):
     
     # Support 테이블에 팀 선택 기록 저장
     round = json.loads(event['body'])['round']
-    insert_query = f'INSERT INTO \"Support\" VALUES (\'{user_id}\', \'{battle_id}\', {round}, {team_id}, \'{vote_time}\')'
-    psql_ctx.execute_query(insert_query)
+    if round:
+        insert_query = f'INSERT INTO \"Support\" VALUES (\'{user_id}\', \'{battle_id}\', {round}, {team_id}, \'{vote_time}\')'
+        psql_ctx.execute_query(insert_query)
 
     response = {
         'statusCode': 200,


### PR DESCRIPTION
## 문제 상황
#52 PR을 통해 구현했던 vote 핸들러에서 다음과 같은 질문이 왔습니다.  
> 초기 팀 선택 시 vote로 처리하는데, 여기서 round를 인자로 받네요. 이때는 round를 어떻게 해야 합니까? startRound 호출 전입니다.

이 부분은 확실히 제가 구현하면서 간과한 점이었습니다. 라운드 시작하지도 않은 상태에서 투표를 하는데 round 인자 값을 줄 수 있을리 없습니다. 그래서 생각한 방법은 아래와 같습니다.  
**"round" 값으로 0을 주자**  
0인 값을 받으면 이 투표는 Support 테이블에 로그를 남기지 않고, DynamoDB에만 teamID 값을 갱신하는 방향으로 구현했습니다.  
## 테스트 방법
1. 임의의 유저 1명이 _initJoin_ 을 통해 들어옵니다.
2. _vote_ 를 통해 round 값을 0과 1 이상의 값을 넣고 테스트를 진행합니다.  
3. round == 0 일 경우, Support 테이블에 기록이 남지 **않고** DynamoDB의 teamID 값에 반영되는지 확인합니다.
4. round >= 0 일 경우, Support 테이블과 DynamoDB에 **모두** 기록이 남는지 확인합니다.