### PR TITLE
Feat: Opinion filtering

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,4 +9,5 @@ psycopg2-binary==2.9.5
 pytest==7.2.2
 redis==4.5.1
 tomli==2.0.1
+openai==0.27.7
 boto3

--- a/backend/src/game/app.py
+++ b/backend/src/game/app.py
@@ -4,6 +4,9 @@ import time
 import random
 import csv
 import string
+import os
+import openai
+
 from datetime import datetime
 from copy import deepcopy
 
@@ -16,6 +19,7 @@ from src.utility.websocket import wsclient
 
 dynamo_db = boto3.client(**dynamo_db_config)
 psql_ctx = PostgresContext(**db_config)
+openai.api_key = os.getenv("OPENAI_API_KEY")
 
 
 def hello():
@@ -131,13 +135,31 @@ def send_handler(event, context, wsclient):
             'body': json.dumps({'message': "Cannot find your connection information"})
         }
 
-    # PK: userId, battleId, roundNo, time
-    # extra fields: noOfLikes, content, status
-    round, num_of_likes = json.loads(event['body'])['round'], 0
-    opinion = json.loads(event['body'])['opinion']
+
     user_id, battle_id, team_id, nickname = my_info['userID']['S'], my_info[
         'battleID']['S'], my_info['teamID']['S'], my_info['nickname']['S']
     status = "CANDIDATE"
+
+    # PK: userId, battleId, roundNo, time
+    # extra fields: noOfLikes, content, status
+    round, num_of_likes = get_single_current_round(battle_id), 0
+    opinion = json.loads(event['body'])['opinion']
+
+    if filter_opinion(opinion) == 1:
+        wsclient.send(
+            connection_id=my_connection_id,
+            data={
+                "action": "recvOpinion",
+                "message": "That's bad opinion"
+            }
+        )
+
+        response = {
+            'statusCode': 422,
+            'body': 'Send bad opinion!'
+        }
+    
+        return response
 
     insert_query = f'INSERT INTO \"Opinion\" (\"userId\", \"battleId\", \"roundNo\", \"noOfLikes\", content, \"timestamp\", \"publishTime\", \"dropTime\", \"status\") VALUES (\'{user_id}\', \'{battle_id}\', {round}, {num_of_likes}, \'{opinion}\', NOW() AT TIME ZONE \'UTC\' + INTERVAL \'9 hours\', NULL, NULL, \'{status}\')'
     psql_ctx.execute_query(insert_query)
@@ -1034,24 +1056,21 @@ def like_handler(event, context, wsclient):
     }
     return response
 
-def get_single_current_round(battle_id):
-    # Get current round from DynamoDB
-    with PostgresContext(**db_config) as psql_ctx:
-        with psql_ctx.cursor() as psql_cursor:
-            round_query = f"""
-                    SELECT * FROM \"Round\" WHERE \"battleId\"=\'{battle_id}\'
-                    AND \"endTime\" IS NULL 
-                    AND \"startTime\" IS NOT NULL
-                    ORDER BY \"roundNo\" ASC
-                    LIMIT 1;
-                    """
-            psql_cursor.execute(round_query)
+def filter_opinion(opinion):
+    prompt = f'''
+    아래의 backtick으로 감싸진 문장은 어떤 토론에서 제시된 의견이다. 
+    문장을 확인하고 비방 및 욕설이 있는 의견 혹은 남에게 몹시 불쾌감을 주는 의견이라면 1, 아니라면 0의 값을 return해라.
+    이 때, 반환값은 python의 int() 함수를 사용하여 타입 캐스팅이 가능해야 한다.
+    ```
+    {opinion}
+    ```
+    '''
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[
+            {"role": "user", "content": prompt}
+        ]
+    )
 
-            rows = psql_cursor.fetchall()
-            psql_ctx.commit()
-    parsed_rows = parse_sql_result(
-        rows=rows, keys=["battleId", "roundNo", "startTime", "endTime", "description"])
-    if parsed_rows and type(parsed_rows) is list:
-        return parsed_rows[0]["roundNo"]
-    else:
-        return -1
+    message = response.choices[0].message.content
+    return int(message.strip())


### PR DESCRIPTION
본 PR은 의견 필터링 기능의 추가를 위해 작성되었습니다. 본 필터링의 대상은 다음과 같습니다.
- 공격성이 짙은 의견
- 비방 및 모욕
- 욕설과 불쾌한 표현

### 사전 준비
- Notion에서 ChatGPT 키 값을 복사해 개인의 프로젝트 디렉토리에 존재하는 `.envrc` 파일에 `OPENAI_API_KEY=<key string>` 추가한다.
- requirements.txt를 이용해 `openai` 라이브러리를 설치

### 테스트 방법
기존에 했던 것처럼 sendOpinion 액션을 이용한 의견 보내기 테스트를 진행합니다. 테스트를 하면서 부적절한 의견인데 DB에 반영되는 상황이 있는지도 확인해주시면 좋을 것 같습니다.

### API 스펙
- 적절치 못한 의견을 보냈을 때의 응답
```json
{
    "action": "recvOpinion",
    "message": "That's bad opinion"
}
```
적절한 의견을 보내면 sendOpinion의 응답과 같습니다.

### 주의사항(필독)
1. 노션에 적힌 API key가 유효하지 않을 수 있습니다. 개발과 테스트의 경우 개인 api key를 통해 진행했습니다. 이와 관련하여 문제가 생기면 담당자가 조치해주세요.
2. sendOpinion의 액션의 경우 round 관련해서 여전히 클라이언트에게 정보를 제공받는 코드로 되어있었습니다. 해당 부분은 제가 임의로 고쳐서 현재 라운드 정보를 백엔드에서 기입하는 걸로 바꿨습니다.
3. Internal server error가 발생할 수도 있습니다. 그렇다면 serverless.yml 파일을 수정해 send-handler의 timeout 값을 2초 정도 늘려주시면 될 것 같습니다.