### PR TITLE
Downgrading urllib3 package

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,4 +10,5 @@ pytest==7.2.2
 redis==4.5.1
 tomli==2.0.1
 openai==0.27.7
+urllib3<2
 boto3


### PR DESCRIPTION
배포 테스트 시 WebSocket에 접속하려면 502 Error를 얻었습니다.  
@Binsk-dev 가 준 [Github 링크](https://github.com/psf/requests/issues/6443)에 따르면, `urllib3` 패키지 버전 문제였던 것으로 판단됩니다.  
따라서 `requirements.txt` 파일에서 아래의 내용을 한 줄 추가했습니다.  
`urllib3<2`
바꾼 후에 다시 테스트를 한 결과, 정상적으로 WebSocket에 연결됐습니다. dev 브랜치에 날렸다 다시 master로 날리기에는 시간이 없다고 판단하기에 PR을 master에 날립니다.